### PR TITLE
Pass along the version tag in upload calls

### DIFF
--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -10,6 +10,7 @@ import stat
 import time
 import subprocess
 import re
+import pkg_resources
 
 sys.tracebacklimit = 0
 
@@ -140,6 +141,8 @@ def upload(
         print("ERROR: input files must be same type")
         raise Exception()
 
+    # Get version of CLI from setuptools
+    version = pkg_resources.require("idseq")[0].version
     data = {
         "sample": {
             "name": sample_name,
@@ -153,7 +156,8 @@ def upload(
                 } for f in files
             ],
             "status": "created"
-        }
+        },
+        "client": version
     }
 
     if preload_s3_path:

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -155,9 +155,9 @@ def upload(
                     "parts": ", ".join(f.parts()),
                 } for f in files
             ],
-            "status": "created"
-        },
-        "client": version
+            "status": "created",
+            "client": version
+        }
     }
 
     if preload_s3_path:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='idseq',
-      version='0.3.1',
+      version='0.3.2',
       description='Idseq CLI',
       url='http://github.com/chanzuckerberg/idsdeq-cli',
       author='Chan Zuckerberg Initiative, LLC',


### PR DESCRIPTION
- Pass along the version tag in upload calls so that the web server can expire old CLI versions later
- Doing this instead of making a `__version__.py` file in /idseq b/c `idseq/__init__.py` has other dependencies too (https://stackoverflow.com/questions/2058802/how-can-i-get-the-version-defined-in-setup-py-setuptools-in-my-package)
- Tested locally with local web running
- Accompanying idseq-web PR: https://github.com/chanzuckerberg/idseq-web/pull/1341