### PR TITLE
Allow user to specify chunk size for splitting upload into smaller files

### DIFF
--- a/idseq/__init__.py
+++ b/idseq/__init__.py
@@ -2,6 +2,7 @@ import argparse
 import re
 import sys
 from idseq import uploader
+from idseq.uploader import DEFAULT_MAX_PART_SIZE_IN_MB
 
 
 def validate_file(path, name):
@@ -124,21 +125,27 @@ def main():
         type=int,
         help='Memory requirement in MB')
     parser.add_argument(
-        '--host_id',
+        '--host-id',
         metavar='value',
         type=int,
         help='Host Genome Id')
     parser.add_argument(
-        '--host_genome_name',
+        '--host-genome-name',
         metavar='name',
         type=str,
         default="Human",
         help='Host Genome Name')
     parser.add_argument(
-        '--job_queue',
+        '--job-queue',
         metavar='name',
         type=str,
         help='Job Queue')
+    parser.add_argument(
+        '--uploadchunksize',
+        metavar='value',
+        type=int,
+        default=DEFAULT_MAX_PART_SIZE_IN_MB,
+        help='Break up uploaded files into chunks of this size in MB')
 
     args = parser.parse_args()
 
@@ -173,7 +180,8 @@ def main():
                     args.samplememory,
                     args.host_id,
                     args.host_genome_name,
-                    args.job_queue)
+                    args.job_queue,
+                    args.uploadchunksize)
             except:
                 print("Failed to upload %s" % sample)
         print("\nDONE\n")
@@ -206,5 +214,6 @@ def main():
         args.samplememory,
         args.host_id,
         args.host_genome_name,
-        args.job_queue)
+        args.job_queue,
+        args.uploadchunksize)
     print("\nDONE\n")


### PR DESCRIPTION
Test plan:
Jamess-Macbook-Pro-2:temp2 jwang$ idseq -t H7nyWyPxyQQPuo6hZkWd -p 'CI' -s 'CLI test 6/19 9' -u https://staging.idseq.net -e jsheu@chanzuckerberg.com --r1 test_R1.fastq.gz --r2 test_R2.fastq.gz --uploadchunksize 2
You agree that the data you are uploading to IDseq has been lawfully collected and that you have all necessary consent and authorization to upload it for the purposes outlined in IDseq's Terms of Use (https://idseq.net/terms).
Proceed (y/n)? y
Uploading sample CLI test 6/19 9
splitting large file into 2 MB chunks...
splitting large file into 2 MB chunks...
successfully created entry
Uploading 2 files
Uploading test_R1.fastq.gz__AWS-MULTI-PART-aa:
100.0 % 
Done.100.0 % 
Done.Uploading test_R1.fastq.gz__AWS-MULTI-PART-ab:
100.0 % 
Done.100.0 % 
Done.Uploading test_R1.fastq.gz__AWS-MULTI-PART-ac:
100.0 % 
Done.100.0 % 
Done.Uploading test_R1.fastq.gz__AWS-MULTI-PART-ad:
100.0 % 
Done.100.0 % 
Done.Uploading test_R2.fastq.gz__AWS-MULTI-PART-aa:
100.0 % 
Done.100.0 % 
Done.Uploading test_R2.fastq.gz__AWS-MULTI-PART-ab:
100.0 % 
Done.100.0 % 
Done.Uploading test_R2.fastq.gz__AWS-MULTI-PART-ac:
100.0 % 
Done.100.0 % 
Done.Uploading test_R2.fastq.gz__AWS-MULTI-PART-ad:
100.0 % 
Done.100.0 % 
Done.

success

DONE


Verified on staging.idseq.net that the file was properly re-assembled