### PR TITLE
Add cat and pig genome to instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For macOS users: We recommend trying the Homebrew package manager to install `aw
 - Replace YOUR_EMAIL with your IDseq email and YOUR_TOKEN with your upload token.
 - Supported file types: .fastq/.fq/.fasta/.fa or .fastq.gz/.fq.gz/.fasta.gz/.fa.gz
 
-- Supported host genome values: 'Human', 'Mosquito', 'Tick', 'Mouse', 'Cat', 'ERCC only'
+- Supported host genome values: 'Human', 'Mosquito', 'Tick', 'Mouse', 'Cat', 'Pig', 'ERCC only'
 
 - Your authentication token for uploading is the token after -t. Keep this private like a password!
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For macOS users: We recommend trying the Homebrew package manager to install `aw
 - Replace YOUR_EMAIL with your IDseq email and YOUR_TOKEN with your upload token.
 - Supported file types: .fastq/.fq/.fasta/.fa or .fastq.gz/.fq.gz/.fasta.gz/.fa.gz
 
-- Supported host genome values: 'Human', 'Mosquito', 'Tick', 'ERCC only', 'Mouse'
+- Supported host genome values: 'Human', 'Mosquito', 'Tick', 'Mouse', 'Cat', 'ERCC only'
 
 - Your authentication token for uploading is the token after -t. Keep this private like a password!
 

--- a/idseq/cli.py
+++ b/idseq/cli.py
@@ -178,7 +178,7 @@ def main():
                         "press Enter to skip): ")
                     if r2 != '':
                         args.r2 = r2
-    host_genomes = ["Human", "Mosquito", "Tick", "Mouse", "ERCC only"]
+    host_genomes = ["Human", "Mosquito", "Tick", "Mouse", "Cat", "ERCC only"]
     host_genome_display = "'" + "' / '".join(host_genomes) + "'"
     while args.host_genome_name not in host_genomes:
         args.host_genome_name = required_input(

--- a/idseq/cli.py
+++ b/idseq/cli.py
@@ -178,7 +178,7 @@ def main():
                         "press Enter to skip): ")
                     if r2 != '':
                         args.r2 = r2
-    host_genomes = ["Human", "Mosquito", "Tick", "Mouse", "Cat", "ERCC only"]
+    host_genomes = ["Human", "Mosquito", "Tick", "Mouse", "Cat", "Pig", "ERCC only"]
     host_genome_display = "'" + "' / '".join(host_genomes) + "'"
     while args.host_genome_name not in host_genomes:
         args.host_genome_name = required_input(


### PR DESCRIPTION
Tested locally:

```
Instructions: https://idseq.net/cli_user_instructions
Starting IDseq command line...

PROJECT:            CI
HOST GENOME:        Cat

SAMPLE NAME:        Cat test 12/10
INPUT FILES:        1_R1.fastq.gz 1_R2.fastq.gz

Confirm details above.
Proceed (y/N)? y for yes or N to cancel: y

I agree that the data I am uploading to IDseq has been lawfully collected and that I have all the necessary consents, permissions, and authorizations needed to collect, share, and export data to IDseq as outlined in the Terms (https://assets.idseq.net/Terms.pdf) and Data Privacy Notice (https://assets.idseq.net/Privacy.pdf).
Proceed (y/N)? y for yes or N to cancel: y

Preparing to uploading sample "Cat test 12/10" ...
Connected to the server.
2 files to upload...

Uploading 1_R1.fastq.gz...
100.0 %
Done.

Uploading 1_R2.fastq.gz...
100.0 %
Done.
```