### PR TITLE
[Multipart Uploads] Fix python3 bytes error

### DIFF
--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -43,7 +43,7 @@ class File():
                                             part_prefix),
                 shell=True)
             return subprocess.check_output(
-                "ls {}*".format(part_prefix), shell=True).splitlines()
+                "ls {}*".format(part_prefix), shell=True).decode("utf-8").splitlines()
         else:
             return [self.path]
 


### PR DESCRIPTION
- Fix bug reported by https://github.com/chanzuckerberg/idseq-cli/issues/42
- decode was used in another place but not applied here


- Works now:
![screen shot 2019-02-14 at 4 13 26 pm](https://user-images.githubusercontent.com/5652739/52826064-3250b380-3074-11e9-91e1-153593c08633.png)
