### PR TITLE
[Bug] Fix metadata validation error handling

### DIFF
--- a/idseq/cli.py
+++ b/idseq/cli.py
@@ -2,7 +2,7 @@ import argparse
 import re
 import requests
 import traceback
-from . import uploader
+import uploader
 
 from builtins import input
 from future.utils import viewitems

--- a/idseq/cli.py
+++ b/idseq/cli.py
@@ -2,7 +2,7 @@ import argparse
 import re
 import requests
 import traceback
-import uploader
+from . import uploader
 
 from builtins import input
 from future.utils import viewitems

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -276,7 +276,7 @@ def get_user_metadata(base_url, headers, sample_names, project_id):
                 headers=headers,
             )
             errors = display_metadata_errors(resp)
-        except (OSError, json.decoder.JSONDecodeError, requests.exceptions.RequestException) as err:
+        except (OSError, ValueError, requests.exceptions.RequestException) as err:
             errors = [str(err)]
             print(errors)
 
@@ -307,10 +307,14 @@ def display_metadata_errors(resp):
         if len(group) != 0:
             print("\n===== {} =====".format(issue_type.capitalize()))
             for issue in group:
-                print()
-                issue.pop("isGroup", None)  # Ignore field
-                for msg in issue.values():
-                    print(msg)
+                # TODO: Backend may return str or issue groups. Can consolidate.
+                if type(issue) == str:  # Won't work for unicode
+                    print(issue)
+                else:
+                    print()
+                    issue.pop("isGroup", None)  # Ignore field
+                    for msg in issue.values():
+                        print(msg)
     return issues.get("errors", {})
 
 


### PR DESCRIPTION
### Description
- This fixes 2 bugs a user encountered when uploading a CSV.
- First is that json.decoder.JSONDecodeError only became available in Python3.5, so in earlier versions it would throw ValueError (and JSONDecodeError is a type of ValueError).
- Second is that the backend may return issue strings or group objects. The CLI was expecting group objects. This could be consolidated on the backend.

### Demo
Before:
```
Enter the metadata file: NextSeq.csv

===== Errors =====

AttributeError: 'module' object has no attribute 'JSONDecodeError'
```

Before:
```
Enter the metadata file: NextSeq.csv

===== Errors =====

AttributeError: 'str' object has no attribute 'pop'
```

After:
```
Enter the metadata file: NextSeq.csv

===== Errors =====

"Host Genome" column is required.
```

### Test and Reproduce
- Pull the branch, install, run `idseq` with your credentials, follow the steps to upload a sample file and scratch metadata CSV. See string errors like `"Host Genome" column is required.` or grouped errors for ones like invalid metadata options.