### PR TITLE
Remove outdated list of hosts

### DIFF
--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -256,7 +256,6 @@ def get_user_agreement():
 def print_metadata_instructions():
     print(
         "\nInstructions: https://idseq.net/metadata/instructions"
-        "\nHost genomes: C.elegans, Cat, ERCC only, Human, Mosquito, Mouse, Pig, Tick"
         "\nMetadata dictionary: https://idseq.net/metadata/dictionary"
         "\nMetadata CSV template: https://idseq.net/metadata/metadata_template_csv"
     )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='idseq',
-      version='0.7.0',
+      version='0.7.1',
       description='IDseq CLI',
       url='http://github.com/chanzuckerberg/idsdeq-cli',
       author='Chan Zuckerberg Initiative, LLC',


### PR DESCRIPTION
* Remove outdated list of hosts. 
* Hard to keep in sync. Users can access instructions.