### PR TITLE
Make uploader python based (remove shell commands)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Check out our repositories:
 - [idseq-web](https://github.com/chanzuckerberg/idseq-web) - Frontend portal
 - [idseq-dag](https://github.com/chanzuckerberg/idseq-dag) - Bioinformatics pipeline and workflow engine
 - [idseq-cli](https://github.com/chanzuckerberg/idseq-cli) - Command line upload interface (here)
-- [idseq-bench](https://github.com/chanzuckerberg/idseq-bench) - Pipeline benchmarking tools 
+- [idseq-bench](https://github.com/chanzuckerberg/idseq-bench) - Pipeline benchmarking tools
 
 
 ## Usage Instructions
@@ -50,10 +50,8 @@ For macOS users: We recommend trying the Homebrew package manager to install `aw
 
 - You will be prompted to upload metadata in a CSV file with your samples. This is also where you will specify the Host Genome.
   - Instructions: https://idseq.net/metadata/instructions
-  - Metadata dictionary: https://idseq.net/metadata/dictionary
+  - Metadata dictionary and supported host genomes: https://idseq.net/metadata/dictionary
   - Metadata CSV template: https://idseq.net/metadata/metadata_template_csv
-
-- Supported host genome values: (see instructions)
 
 - Your authentication token for uploading is the token after -t. Keep this private like a password!
 

--- a/idseq/cli.py
+++ b/idseq/cli.py
@@ -35,14 +35,20 @@ def main():
         '--sample-name',
         metavar='name',
         type=str,
-        help='Sample name. It should be unique within a project')
+        help='Sample name. It should be unique within a project. Ignored for bulk uploads.')
+    parser.add_argument(
+        '-m',
+        '--metadata',
+        metavar='file',
+        type=str,
+        help='Metadata local file path.')
     parser.add_argument(
         '-u',
         '--url',
         metavar='url',
         type=str,
         default='https://idseq.net',
-        help='idseq website url: i.e. https://idseq.net by default')
+        help='IDseq website url: i.e. https://idseq.net by default')
     parser.add_argument(
         '-e',
         '--email',
@@ -59,12 +65,12 @@ def main():
         '--r1',
         metavar='file',
         type=str,
-        help='read 1 file path. could be a local file or s3 path')
+        help='Read 1 file path. Could be a local file or s3 path')
     parser.add_argument(
         '--r2',
         metavar='file',
         type=str,
-        help='read 2 file path (optional). could be a local file or s3 path')
+        help='Read 2 file path (optional). Could be a local file or s3 path')
     parser.add_argument(
         '-b',
         '--bulk',
@@ -133,7 +139,7 @@ def main():
         print("\nSamples and files to upload:")
         for sample, files in viewitems(samples2files):
             print_sample_files_info(sample, files)
-        csv_metadata = uploader.get_user_metadata(args.url, headers, list(samples2files.keys()), args.project_id)
+        csv_metadata, metadata_file = uploader.get_user_metadata(args.url, headers, list(samples2files.keys()), args.project_id, args.metadata)
         if not args.accept_all:
             uploader.get_user_agreement()
         for sample, files in viewitems(samples2files):
@@ -177,8 +183,8 @@ def upload_sample(sample_name, file_0, file_1, headers, args, csv_metadata):
 
 
 def print_sample_files_info(sample, files):
-    print("{:20}{}".format("SAMPLE NAME:", sample))
-    print("{:20}{}".format("INPUT FILES:", " ".join(files)))
+    print("{:20}{}".format("Sample name:", sample))
+    print("{:20}{}".format("Input files:", " ".join(files)))
 
 
 def sample_error_text(sample, err):

--- a/idseq/cli.py
+++ b/idseq/cli.py
@@ -139,7 +139,7 @@ def main():
         print("\nSamples and files to upload:")
         for sample, files in viewitems(samples2files):
             print_sample_files_info(sample, files)
-        csv_metadata, metadata_file = uploader.get_user_metadata(
+        csv_metadata = uploader.get_user_metadata(
             args.url, headers, list(samples2files.keys()), args.project_id, args.metadata)
         if not args.accept_all:
             uploader.get_user_agreement()
@@ -156,7 +156,7 @@ def main():
         validate_file(args.r2, 'R2')
         input_files.append(args.r2)
     print_sample_files_info(args.sample_name, input_files)
-    csv_metadata = uploader.get_user_metadata(args.url, headers, [args.sample_name], args.project_id)
+    csv_metadata = uploader.get_user_metadata(args.url, headers, [args.sample_name], args.project_id, args.metadata)
     if not args.accept_all:
         uploader.get_user_agreement()
     upload_sample(args.sample_name, args.r1, args.r2, headers, args, csv_metadata[args.sample_name])

--- a/idseq/cli.py
+++ b/idseq/cli.py
@@ -139,7 +139,8 @@ def main():
         print("\nSamples and files to upload:")
         for sample, files in viewitems(samples2files):
             print_sample_files_info(sample, files)
-        csv_metadata, metadata_file = uploader.get_user_metadata(args.url, headers, list(samples2files.keys()), args.project_id, args.metadata)
+        csv_metadata, metadata_file = uploader.get_user_metadata(
+            args.url, headers, list(samples2files.keys()), args.project_id, args.metadata)
         if not args.accept_all:
             uploader.get_user_agreement()
         for sample, files in viewitems(samples2files):

--- a/idseq/cli.py
+++ b/idseq/cli.py
@@ -136,6 +136,10 @@ def main():
     if args.bulk:
         samples2files = uploader.detect_samples(args.bulk)
 
+        if len(samples2files) == 0:
+            print("No proper single or paired samples detected")
+            return
+
         print("\nSamples and files to upload:")
         for sample, files in viewitems(samples2files):
             print_sample_files_info(sample, files)

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -317,7 +317,7 @@ def get_user_metadata(base_url, headers, sample_names, project_id, metadata_file
                 for row in list(csv.DictReader(file_data)):
                     name = pop_match_in_dict(["sample_name", "Sample Name"], row)
                     csv_data[name] = row
-            return csv_data, metadata_file
+            return csv_data
 
 
 # Display issues with the submitted metadata CSV based on the server response

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -249,7 +249,13 @@ def upload(sample_name, project_id, headers, url, r1, r2, chunk_size, csv_metada
             data=json.dumps(update),
             headers=headers)
 
-        if resp.status_code != 200:
+        has_file_parts = any(len(parts) > 1 for parts in all_file_parts)
+        if resp.status_code == 504 and has_file_parts:
+            # Note: Not ideal, but for now idseq-web times out trying to concatenate file parts on the server
+            print('Sample is being processed on our server. Check for status on IDseq https://idseq.net')
+            remove_files(all_file_parts)
+            return
+        elif resp.status_code != 200:
             print('Sample was not successfully uploaded. Status code: {}, '
                   'Sample name: {}'.format(str(resp.status_code), str(sample_name)))
             remove_files(all_file_parts)

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -44,6 +44,7 @@ class File():
             return [self.path]
 
     def split_file(self, max_part_size, prefix):
+        # Using MB (10^6) instead of MiB (2^16)
         print("Splitting large file into {} MB chunks...".format(int(max_part_size // 1E6)))
         if not os.path.isfile(self.path):
             print("Sample file not found: {}".format(self.path))

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -248,8 +248,8 @@ def get_user_agreement():
     msg = "\nI agree that the data I am uploading to IDseq has been lawfully " \
           "collected and that I have all the necessary consents, permissions, " \
           "and authorizations needed to collect, share, and export data to " \
-          "IDseq as outlined in the Terms (https://assets.idseq.net/Terms.pdf) and Data " \
-          "Privacy Notice (https://assets.idseq.net/Privacy.pdf).\nProceed (y/N)? y for " \
+          "IDseq as outlined in the Terms (https://idseq.net/terms) and Data " \
+          "Privacy Notice (https://idseq.net/privacy).\nProceed (y/N)? y for " \
           "yes or N to cancel: "
     prompt(msg)
 

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -262,7 +262,6 @@ def print_metadata_instructions():
     )
 
 def get_user_metadata(base_url, headers, sample_names, project_id, metadata_file=None):
-
     instructions_printed = False
 
     if not metadata_file:

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -318,7 +318,7 @@ def get_user_metadata(base_url, headers, sample_names, project_id, metadata_file
                 for row in list(csv.DictReader(file_data)):
                     name = pop_match_in_dict(["sample_name", "Sample Name"], row)
                     csv_data[name] = row
-            return csv_data, metadata_file
+            return csv_data
 
 
 # Display issues with the submitted metadata CSV based on the server response

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -50,7 +50,6 @@ class File():
             return []
 
         partial_files = []
-        file_size = os.path.getsize(self.path)
         suffix_iter = product(ascii_lowercase, repeat=2)
         try:
             with open(self.path, 'rb') as fread:

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -44,9 +44,9 @@ class File():
             return [self.path]
 
     def split_file(self, max_part_size, prefix):
-        print(f"Splitting large file into {int(max_part_size // 1E6)} MB chunks...")
+        print("Splitting large file into {} MB chunks...".format(int(max_part_size // 1E6)))
         if not os.path.isfile(self.path):
-            print(f"Sample file not found: {self.path}")
+            print("Sample file not found: {}".format(self.path))
             return []
 
         partial_files = []
@@ -60,7 +60,7 @@ class File():
                         fwrite.write(chunk)
             return partial_files
         except StopIteration:
-            print(f"[ERROR] File too large")
+            print("[ERROR] File too large")
             remove_files(partial_files)
 
 

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -303,7 +303,6 @@ def get_user_metadata(base_url, headers, sample_names, project_id, metadata_file
             errors = [str(err)]
             print(errors)
 
-
         if len(errors) != 0:
             print("\n====================")
             if not instructions_printed:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='idseq',
-      version='0.7.2',
+      version='0.7.3',
       description='IDseq CLI',
       url='http://github.com/chanzuckerberg/idsdeq-cli',
       author='Chan Zuckerberg Initiative, LLC',


### PR DESCRIPTION
### Description

* Removes shell commands like `split` and `ls` and use python std library
* Makes pipeline compatible with Windows
* TODO: 

### Notes

* Uploading large files makes the last step - updating the status - to fail by timeout. The server spends a long time concatenating multiparts. The pipeline still gets triggered but the user receives an error.

### Test Plan

* With python2 and 3, test upload single and double reads files and single and bulk upload