### PR TITLE
Add logging for part numbers during upload.

### DIFF
--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -228,9 +228,12 @@ def upload(sample_name, project_id, headers, url, r1, r2, chunk_size, csv_metada
         for raw_input_file in sample_data['input_files']:
             presigned_urls = raw_input_file['presigned_url'].split(", ")
             input_parts = raw_input_file["parts"].split(", ")
-            for i, file in enumerate(input_parts):
-                presigned_url = presigned_urls[i]
-                with Tqio(file, i, num_files) as f:
+            for part_index, file in enumerate(input_parts):
+                presigned_url = presigned_urls[part_index]
+                print('Uploading {} (part {} of {})...'.format(
+                    file, part_index, len(input_parts)
+                ))
+                with Tqio(file, part_index, num_files) as f:
                     resp_put = requests.put(presigned_url, data=f)
                     if resp_put.status_code != 200:
                         print('Sample was not successfully uploaded. Status code: {}, '
@@ -417,7 +420,6 @@ def pop_match_in_dict(keys, dictionary):
 class Tqio(io.BufferedReader):
     def __init__(self, file_path, i, count):
         super(Tqio, self).__init__(io.open(file_path, "rb"))
-        self.write_stdout("\nUploading {}...\n\r".format(file_path))
         self.progress = 0
         self.chunk_idx = 0
         self.total = os.path.getsize(file_path)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='idseq',
-      version='0.8.0',
+      version='0.8.1',
       description='IDseq CLI',
       url='http://github.com/chanzuckerberg/idsdeq-cli',
       author='Chan Zuckerberg Initiative, LLC',


### PR DESCRIPTION
The current CLI doesn't show the current part number, which can be helpful to track progress.

New output:
![Screen Shot 2019-08-20 at 2 06 50 PM](https://user-images.githubusercontent.com/837004/63384716-455e7c00-c354-11e9-8d27-174eb5a941d9.png)
