### PR TITLE
Handle error if project name is duplicated.

### DIFF
--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -404,6 +404,9 @@ def validate_project(base_url, headers, project_name):
                 data=json.dumps({"project": {"name": project_name}}),
                 headers=headers
             )
+            if resp.status_code == 422:
+                print("Project name is too similar to an existing project. Please try another name.")
+                continue
             resp = resp.json()
             print("Project created!")
             return resp["name"], resp["id"]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='idseq',
-      version='0.8.1',
+      version='0.8.2',
       description='IDseq CLI',
       url='http://github.com/chanzuckerberg/idsdeq-cli',
       author='Chan Zuckerberg Initiative, LLC',


### PR DESCRIPTION
If a project exists called "TEST" and you enter the project "Test", it will say the project doesn't exist. If you press Enter, it will try to create this project.

idseq has a case-insensitive uniqueness check on the project name, so the create call will actually cause an HTTP error, which then causes the CLI to crash (since there is no json to parse).

We now handle this error more gracefully.