### PR TITLE
Limit local path info in input_files_attributes

### DIFF
--- a/idseq/cli.py
+++ b/idseq/cli.py
@@ -2,7 +2,7 @@ import argparse
 import re
 import requests
 import traceback
-from . import uploader
+import uploader
 
 from builtins import input
 from future.utils import viewitems

--- a/idseq/cli.py
+++ b/idseq/cli.py
@@ -2,7 +2,7 @@ import argparse
 import re
 import requests
 import traceback
-import uploader
+from . import uploader
 
 from builtins import input
 from future.utils import viewitems

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -16,7 +16,7 @@ from future.utils import viewitems
 from itertools import product
 from string import ascii_lowercase
 
-from . import locations
+import locations
 
 sys.tracebacklimit = 0
 
@@ -184,9 +184,9 @@ def upload(sample_name, project_id, headers, url, r1, r2, chunk_size, csv_metada
                 "input_files_attributes": [
                     {
                         "name": os.path.basename(f.path),
-                        "source": f.path,
+                        "source": f.path if f.source_type() == 's3' else os.path.basename(f.path),
                         "source_type": f.source_type(),
-                        "parts": ", ".join(file_parts),
+                        "parts": ", ".join([os.path.basename(f) for f in file_parts]),
                     }
                     for f, file_parts in zip(files, all_file_parts)
                 ],

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -16,7 +16,7 @@ from future.utils import viewitems
 from itertools import product
 from string import ascii_lowercase
 
-import locations
+from . import locations
 
 sys.tracebacklimit = 0
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='idseq',
-      version='0.8.2',
+      version='0.8.3',
       description='IDseq CLI',
       url='http://github.com/chanzuckerberg/idsdeq-cli',
       author='Chan Zuckerberg Initiative, LLC',


### PR DESCRIPTION
## Description
- JIRA: https://jira.czi.team/browse/IDSEQ-1154
- Use os.path.basename for the `source` and `parts` fields.

## Tests

### Before example
`
web_1                      | [2019-09-20T22:01:26] INFO  ActionController::Base :   Parameters: {"samples"=>[{"name"=>"New sample with metadata", "project_id"=>304, "input_files_attributes"=>[{"name"=>"1_R1.fastq.gz", "source"=>"../2019-09-20/1_R1.fastq.gz", "source_type"=>"local", "parts"=>"../2019-09-20/1_R1.fastq.gz"}, {"name"=>"1_R2.fastq.gz", "source"=>"../2019-09-20/1_R2.fastq.gz", "source_type"=>"local", "parts"=>"../2019-09-20/1_R2.fastq.gz"}], "host_genome_name"=>"Human", "status"=>"created"}], "metadata"=>{"New sample with metadata"=>{"sample_type"=>"Blood", "nucleotide_type"=>"RNA", "sample_unit"=>"", "collection_date"=>"2019-01", "Collection Location"=>"Uganda", "collected_by"=>"Biohub", "reported_sex"=>"", "comp_sex"=>"", "host_sex"=>"", "library_prep"=>"Illumina", "sequencer"=>"NextSeq"}}, "client"=>"0.8.3", "sample"=>{}}
`

### After example
`
web_1                      | [2019-09-20T22:03:54] INFO  ActionController::Base :   Parameters: {"samples"=>[{"name"=>"New sample with metadata", "project_id"=>304, "input_files_attributes"=>[{"name"=>"1_R1.fastq.gz", "source"=>"1_R1.fastq.gz", "source_type"=>"local", "parts"=>"1_R1.fastq.gz"}, {"name"=>"1_R2.fastq.gz", "source"=>"1_R2.fastq.gz", "source_type"=>"local", "parts"=>"1_R2.fastq.gz"}], "host_genome_name"=>"Human", "status"=>"created"}], "metadata"=>{"New sample with metadata"=>{"sample_type"=>"Blood", "nucleotide_type"=>"RNA", "sample_unit"=>"", "collection_date"=>"2019-01", "Collection Location"=>"Uganda", "collected_by"=>"Biohub", "reported_sex"=>"", "comp_sex"=>"", "host_sex"=>"", "library_prep"=>"Illumina", "sequencer"=>"NextSeq"}}, "client"=>"0.8.3", "sample"=>{}}
`

- Tested with single and multi-parting.