### PR TITLE
python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: python
 python:
 - '2.7'
 - pypy
-- '3.8'
+- '3.7'
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: python
 python:
 - '2.7'
 - pypy
+- '3.8'
 script:
   - make

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For macOS users: We recommend trying the Homebrew package manager to install `aw
 ### (2) Install the IDseq CLI:
 
 `pip install git+https://github.com/chanzuckerberg/idseq-cli.git --upgrade`
-- Tips: Make sure you have Python 2 or 3 installed already. Try running pip --version or python --version.
+- Tips: Make sure you have Python installed already. Try running pip --version or python --version.
 
 - Try running with pip2 or pip3 depending on your configuration. Try sudo pip if you run into permissions errors. You can use this same command in the future to update the CLI if needed.
 


### PR DESCRIPTION
Python 2 is EOL soon, so we should start trying to nudge people towards using Python 3.

This PR starts to build with python 3 in parallel and removes a small note in the docs referencing python 2.