### PR TITLE
Show better error message when user uses the wrong login credentials

### DIFF
--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -386,7 +386,11 @@ def display_metadata_errors(resp):
 
 def validate_project(base_url, headers, project_name):
     print("Checking project name...")
-    all_projects = requests.get(base_url + "/projects.json", headers=headers).json()
+    resp = requests.get(base_url + "/projects.json", headers=headers)
+    if resp.status_code == 401:
+        print("Invalid email or token. Please double-check the formatting in the instructions.")
+        return
+    all_projects = resp.json()
     names_to_ids = {}
 
     for project in all_projects["projects"]:

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -388,8 +388,8 @@ def validate_project(base_url, headers, project_name):
     print("Checking project name...")
     resp = requests.get(base_url + "/projects.json", headers=headers)
     if resp.status_code == 401:
-        print("Invalid email or token. Please double-check the formatting in the instructions.")
-        return
+        print("Invalid email or token. Please double-check your formatting and try again.")
+        quit()
     all_projects = resp.json()
     names_to_ids = {}
 


### PR DESCRIPTION
### Description
- Quick fix that came up with user support. This call is the first to IDseq servers, so the user will see something like:
```
Checking project name...
JSONDecodeError: Expecting value: line 1 column 2 (char 1)
```
if they try to use invalid credentials.

### Notes
- As a rule we should probably check `resp.status_code` instead of chaining `.json()` to request responses.

### Testing
- Try a regular CLI command but change your token to something incorrect. You'll see the error message as expected.