### PR TITLE
Fix open call to work with python2 and python3

### DIFF
--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -59,7 +59,7 @@ class File():
             with open(self.path, 'rb') as fread:
                 for chunk in iter(lambda: fread.read(max_part_size), b''):
                     partial_files.append("{}{}".format(prefix, ''.join(next(suffix_iter))))
-                    with open(partial_files[-1], 'bw') as fwrite:
+                    with open(partial_files[-1], 'wb') as fwrite:
                         fwrite.write(chunk)
             return partial_files
         except StopIteration:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='idseq',
-      version='0.8.5',
+      version='0.8.6',
       description='IDseq CLI',
       url='http://github.com/chanzuckerberg/idsdeq-cli',
       author='Chan Zuckerberg Initiative, LLC',


### PR DESCRIPTION
### Description

* In Python 2, the order of the mode string is relevant

### Test

* Run open in both python2 and python3 using `open(file, "wb")`