### PR TITLE
Add option to skip duplicates on upload 

### DIFF
--- a/idseq/cli.py
+++ b/idseq/cli.py
@@ -92,6 +92,10 @@ def main():
         '--skip-geosearch',
         action='store_true',
         help='Use this argument to skip searching for geo-location via third-party API')
+    parser.add_argument(
+        '--skip-duplicates',
+        action='store_true',
+        help='Use this argument with bulk mode (-b) to skip samples that have already been uploaded')
     args = parser.parse_args()
 
     print("Instructions: https://idseq.net/cli_user_instructions\nStarting "
@@ -158,11 +162,13 @@ def upload_sample(sample_name, file_0, file_1, headers, args, csv_metadata):
     try:
         uploader.upload(
             sample_name, args.project_id, headers, args.url, file_0, file_1,
-            args.uploadchunksize, csv_metadata
+            args.uploadchunksize, csv_metadata, args.skip_duplicates,
         )
     except requests.exceptions.RequestException as e:
         sample_error_text(sample_name, e)
         network_err_text()
+    except ValueError as e:
+        print(f'Skipping {sample_name}: name has already been taken in project {args.project or args.project_id}.')
     except Exception as e:
         traceback.print_exc()
         sample_error_text(sample_name, e)

--- a/idseq/cli.py
+++ b/idseq/cli.py
@@ -168,7 +168,8 @@ def upload_sample(sample_name, file_0, file_1, headers, args, csv_metadata):
         sample_error_text(sample_name, e)
         network_err_text()
     except ValueError as e:
-        print(f'Skipping {sample_name}: name has already been taken in project {args.project or args.project_id}.')
+        print('Skipping {}: name has already been taken in project {}.'.format(
+            sample_name, args.project or args.project_id))
     except Exception as e:
         traceback.print_exc()
         sample_error_text(sample_name, e)

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -222,7 +222,7 @@ def upload(
         else:
             remove_files(all_file_parts)
             errors = resp["errors"]
-            if skip_duplicates and errors[0]['name'] == ['has already been taken']:
+            if skip_duplicates and len(errors) == 1 and errors[0]['name'] == ['has already been taken']:
                 # This error is returned from Rails web app according to the
                 # validation rule on the name attribute. See Sample.rb in the
                 # idseq-web repo.

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -220,6 +220,7 @@ def upload(
         if len(resp.get("errors", {})) == 0:
             print("Connected to the server.")
         else:
+            remove_files(all_file_parts)
             errors = resp["errors"]
             if skip_duplicates and errors[0]['name'] == ['has already been taken']:
                 # This error is returned from Rails web app according to the
@@ -228,7 +229,6 @@ def upload(
                 raise ValueError('name has already been taken')
             else:
                 print("\nFailed. Error response from IDseq server: {}".format(resp["errors"]))
-                remove_files(all_file_parts)
                 return
     else:
         # Handle potential responses without proper error fields

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -228,7 +228,7 @@ def upload(
                 # idseq-web repo.
                 raise ValueError('name has already been taken')
             else:
-                print("\nFailed. Error response from IDseq server: {}".format(resp["errors"]))
+                print("\nFailed. Error response from IDseq server: {}".format(errors))
                 return
     else:
         # Handle potential responses without proper error fields


### PR DESCRIPTION
For synchronizing the contents of a s3 bucket with a idseq project, it helps to make uploads idempotent. That is, a upload command always succeeds when the target project has the desired samples.

For idempotence, this PR adds a `--skip-duplicates` option to `idseq` CLI. 

This is on top of #64 . 

Example run:
```
Starting IDseq command line...
Checking project name...

PROJECT:            gdingle cli test

Samples and files to upload:
Sample name:        RR004_water_2_S23A
Input files:        s3://idseq-samples-staging/samples/365/14220/fastqs/RR004_water_2_S23A_R2_001.fastq
Metadata file:      /Users/gdingle/Desktop/idseq_test_samples/water/clitest2.csv

CSV validation successful!

Preparing to upload sample "RR004_water_2_S23A" ...
Skipping RR004_water_2_S23A: name has already been taken in project gdingle cli test.
```

# Notes

To my surprise, I discovered after writing this PR that the current behavior is to ignore errors in a sample and continue with the next. That seems dangerous and is certainly inconsistent with the web UI. So the net effect of this PR is only to change the message when there is a duplicate. I'm not sure whether it's worth changing the CLI default behavior at this point. 

# Tests

WIth option on:
Run a duplicate sample, see message
Run non-dupe, see no message

With option off:
Run a duplicate sample, see error message
Run non-dupe, see no message
