### PR TITLE
[IDSEQ-2664] Update location match for host genomes to be case-insensitive

### DIFF
--- a/idseq/locations.py
+++ b/idseq/locations.py
@@ -81,7 +81,7 @@ def set_location_matches(csv_data, matched_locations):
                 if value in matched_locations:
                     result = matched_locations[value]
                     is_human = any(
-                        [metadata.get(n) == "Human" for n in constants.HOST_GENOME_ALIASES]
+                        [(metadata.get(n)).lower() == "human" for n in constants.HOST_GENOME_ALIASES]
                     )
                     metadata[field_name] = process_location_selection(result, is_human)
 


### PR DESCRIPTION
# Description
When updating city-specific locations for human metadata, the check for host genome was only matching to "Human" specifically. This PR updates the check to be case-insensitive, so it will also match against "human".

# Tests
Verified that locations will be corrected if "human" is input as the host genome instead of "Human".

# Version
PR to update version here: https://github.com/chanzuckerberg/idseq-web-private/pull/236
- [x] I have increased the appropriate version number of `MIN_CLI_VERSION` in https://github.com/chanzuckerberg/idseq-web/blob/master/app/controllers/samples_controller.rb.
