### PR TITLE
[IDSEQ-3308] Check if host genome included before matching to human

### DIFF
--- a/idseq/locations.py
+++ b/idseq/locations.py
@@ -81,7 +81,7 @@ def set_location_matches(csv_data, matched_locations):
                 if value in matched_locations:
                     result = matched_locations[value]
                     is_human = any(
-                        [(metadata.get(n)).lower() == "human" for n in constants.HOST_GENOME_ALIASES]
+                        [metadata.get(n) and metadata.get(n).lower() == "human" for n in constants.HOST_GENOME_ALIASES]
                     )
                     metadata[field_name] = process_location_selection(result, is_human)
 


### PR DESCRIPTION
# Description
A followup fix to https://github.com/chanzuckerberg/idseq-cli/pull/71; fixes a bug where the user receives a `AttributeError: 'NoneType' object has no attribute 'lower'` error if their metadata file doesn't include all of the host genome aliases.

# Tests
Uploaded a sample using the metadata csv template provided in IDSEQ-3308.

# Version
- [x] I have increased the appropriate version number of `MIN_CLI_VERSION` in https://github.com/chanzuckerberg/idseq-web/blob/master/app/controllers/samples_controller.rb.
