### PR TITLE
Reduce memory usage during file split operation

### DIFF
--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -25,7 +25,7 @@ DEFAULT_MAX_PART_SIZE_IN_MB = 5000
 INPUT_REGEX = "(.+)\.(fastq|fq|fasta|fa)(\.gz|$)"
 PAIRED_REGEX = "(.+)(_R\d)(_001)?\.(fastq|fq|fasta|fa)(\.gz|$)"
 PART_SUFFIX = "__AWS-MULTI-PART-"
-BUFFER_SIZE = 1024 ** 2 # 1 Mb
+BUFFER_SIZE = 1024 ** 2  # 1 Mb
 
 
 class File():

--- a/idseq/uploader.py
+++ b/idseq/uploader.py
@@ -57,7 +57,7 @@ class File():
         partial_files = []
         suffix_iter = product(ascii_lowercase, repeat=2)
         try:
-            buffer = memoryview(bytearray(min(BUFFER_SIZE,max_part_size)))
+            buffer = memoryview(bytearray(min(BUFFER_SIZE, max_part_size)))
             with buffer, open(self.path, 'rb') as fread:
                 for suf in suffix_iter:
                     partial_files.append("{}{}".format(prefix, ''.join(suf)))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='idseq',
-      version='0.8.10',
+      version='0.8.11',
       description='IDseq CLI',
       url='http://github.com/chanzuckerberg/idsdeq-cli',
       author='Chan Zuckerberg Initiative, LLC',


### PR DESCRIPTION
# Description
The current code for file splitting is reading chunks of 5GB each directly into RAM. This is prone to cause memory allocation issues on machines with less RAM. It could also cause strange behaviors on 32 bit platforms.

This PR drastically reduces the memory consumption during file split operation, by pre-allocating a 1Mb transfer buffer that is reused on all subsequent read/write operations on the file streams.

It is important to notice that the _transfer buffer size_ is not the same thing as the _chunk file size_ (although the previous code was treating both as the same thing, and with same size by consequence). The chunk size of 5GB per file is unaffected by this change. The only difference is that read/write operations to the file streams are now made in blocks of 1Mb.

# Tests
- Manual tests directly on the affected method
- Tested with python 2 and python 3.

# Version
~[ ] I have increased the appropriate version number of `MIN_CLI_VERSION`~
I have not increased the version number of `MIN_CLI_VERSION` in https://github.com/chanzuckerberg/idseq-web/blob/master/app/controllers/samples_controller.rb, since this code is not merged yet.
Besides, this change doesn't affect the current interface with IDseq web, so forcing existing users to upgrade their clients is optional (although recommended from a resource usage perspective).