### PR TITLE
Deprecation phase one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [IDseq](https://idseq.net/) &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/chanzuckerberg/idseq-web/blob/master/LICENSE) [![Build Status](https://travis-ci.org/chanzuckerberg/idseq-cli.svg?branch=master)](https://travis-ci.org/chanzuckerberg/idseq-cli)
 
-This project is stable and still maintained, but not actively under development.
+Warning: this CLI will soon be deprecated, consider switching to [version 2](https://github.com/chanzuckerberg/idseq-cli-v2). This project is stable and currently still being maintained, but it is not actively under development. Any new features will be added to version 2. [Here](https://github.com/chanzuckerberg/idseq-cli-v2#differences-from-version-1) is a list of differences from version 1 including exciting new features!
 
 ![logo](https://assets.idseq.net/assets/Logo_Black.png)
 

--- a/idseq/cli.py
+++ b/idseq/cli.py
@@ -23,7 +23,7 @@ def validate_file(path, name):
 
 def main():
     message = "Warning: this CLI will soon be deprecated," + \
-    " consider switching to version 2: https://github.com/chanzuckerberg/idseq-cli-v2\n"
+              " consider switching to version 2: https://github.com/chanzuckerberg/idseq-cli-v2\n"
     print(message, file=sys.stderr)
 
     parser = argparse.ArgumentParser(

--- a/idseq/cli.py
+++ b/idseq/cli.py
@@ -22,7 +22,9 @@ def validate_file(path, name):
 
 
 def main():
-    print("Warning: this CLI will soon be deprecated, consider switching to version 2: https://github.com/chanzuckerberg/idseq-cli-v2\n", file=sys.stderr)
+    message = "Warning: this CLI will soon be deprecated," + \
+    " consider switching to version 2: https://github.com/chanzuckerberg/idseq-cli-v2\n"
+    print(message, file=sys.stderr)
 
     parser = argparse.ArgumentParser(
         description='Submit a sample to idseq. (Accepts fastq or fasta files, single or paired, gzipped or not.)'

--- a/idseq/cli.py
+++ b/idseq/cli.py
@@ -1,7 +1,9 @@
+from __future__ import print_function
 import argparse
 import re
 import requests
 import traceback
+import sys
 from . import uploader
 
 from builtins import input
@@ -20,6 +22,8 @@ def validate_file(path, name):
 
 
 def main():
+    print("Warning: this CLI will soon be deprecated, consider switching to version 2: https://github.com/chanzuckerberg/idseq-cli-v2\n", file=sys.stderr)
+
     parser = argparse.ArgumentParser(
         description='Submit a sample to idseq. (Accepts fastq or fasta files, single or paired, gzipped or not.)'
     )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='idseq',
-      version='0.8.13',
+      version='0.8.14',
       description='IDseq CLI',
       url='http://github.com/chanzuckerberg/idseq-cli',
       author='Chan Zuckerberg Initiative, LLC',


### PR DESCRIPTION
# Description

Helping ease the transition from version 1. We can use the API to force users to update to `0.8.14`, then they will see this new warning without needing to change their workflow immediately.

# Tests

I tested this with both python 3 and python 2 (hence the `__future__` import).

# Version
- [X] I have increased the appropriate version number of `MIN_CLI_VERSION` in https://github.com/chanzuckerberg/idseq-web/blob/master/app/controllers/samples_controller.rb.
- [X] I will run `make release` after merging the PR to release the package to PyPI.
